### PR TITLE
Add JSON-LD scraper and single URL processing job

### DIFF
--- a/README
+++ b/README
@@ -18,3 +18,15 @@ python -m jobs.run_everything
 ```
 
 Environment variables are loaded from `.env` (see `.env.example`).
+
+## Processing a Single URL
+
+The collector can scrape event data from pages that expose JSON-LD metadata.
+For example, to ingest events from the Needham Library events page:
+
+```bash
+python -m jobs.process_url https://needhamlibrary.org/events/
+```
+
+The script fetches the page, extracts any events, and submits them to the
+Superschedules API.

--- a/jobs/process_url.py
+++ b/jobs/process_url.py
@@ -1,0 +1,37 @@
+"""Scrape a single URL for events and post them to the API."""
+from __future__ import annotations
+
+import sys
+from typing import List
+
+import requests
+
+from ingest.api_client import post_event
+from scrapers.jsonld_scraper import scrape_events_from_jsonld
+
+
+def run(url: str) -> None:
+    """Scrape events from ``url`` and post them to the backend."""
+    try:
+        events: List[dict] = scrape_events_from_jsonld(url)
+    except requests.RequestException as exc:
+        print("❌ Failed to fetch page:", exc)
+        return
+
+    if not events:
+        print("No events found at", url)
+        return
+
+    for event in events:
+        try:
+            result = post_event(event)
+            print("✅ Posted:", result.get("title", "<unknown>"))
+        except Exception as exc:  # pragma: no cover - logging only
+            print("❌ Failed to post event:", event.get("title", "<unknown>"), exc)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python -m jobs.process_url <url>")
+        raise SystemExit(1)
+    run(sys.argv[1])

--- a/scrapers/jsonld_scraper.py
+++ b/scrapers/jsonld_scraper.py
@@ -1,0 +1,75 @@
+"""Scrape JSON-LD event data from webpages."""
+from __future__ import annotations
+
+import json
+from typing import Any, List
+
+import requests
+from bs4 import BeautifulSoup
+
+
+def scrape_events_from_jsonld(url: str, source_id: int = 0) -> List[dict[str, Any]]:
+    """Fetch a page and extract events described in JSON-LD.
+
+    Args:
+        url: Page URL containing JSON-LD event data.
+        source_id: Numeric source identifier to include on each event.
+
+    Returns:
+        A list of event dictionaries matching the API schema.
+    """
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+
+    soup = BeautifulSoup(response.text, "html.parser")
+    events: List[dict[str, Any]] = []
+
+    for tag in soup.find_all("script", type="application/ld+json"):
+        try:
+            data = json.loads(tag.string or "")
+        except json.JSONDecodeError:
+            continue
+
+        for item in _extract_event_objects(data):
+            events.append(
+                {
+                    "source_id": source_id,
+                    "external_id": item.get("@id") or item.get("url"),
+                    "title": item.get("name", ""),
+                    "description": item.get("description", ""),
+                    "location": _parse_location(item.get("location")),
+                    "start_time": item.get("startDate"),
+                    "end_time": item.get("endDate"),
+                    "url": item.get("url", url),
+                }
+            )
+
+    return events
+
+
+def _extract_event_objects(data: Any) -> List[dict[str, Any]]:
+    """Return event dicts from a JSON-LD blob."""
+    items: List[dict[str, Any]] = []
+
+    if isinstance(data, list):
+        for obj in data:
+            if isinstance(obj, dict) and obj.get("@type") == "Event":
+                items.append(obj)
+    elif isinstance(data, dict):
+        if data.get("@type") == "Event":
+            items.append(data)
+        elif isinstance(data.get("@graph"), list):
+            for obj in data["@graph"]:
+                if isinstance(obj, dict) and obj.get("@type") == "Event":
+                    items.append(obj)
+
+    return items
+
+
+def _parse_location(location: Any) -> str:
+    """Extract a human-readable location string."""
+    if isinstance(location, dict):
+        return location.get("name") or location.get("address", "")
+    if isinstance(location, str):
+        return location
+    return ""


### PR DESCRIPTION
## Summary
- add utility to parse JSON-LD event data into the API schema
- new job to scrape a single URL and post events to Superschedules backend
- document how to process the Needham Library events page

## Testing
- `python -m jobs.process_url https://needhamlibrary.org/events/` *(fails: ProxyError - Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6896559a6e708333b1afc97a39b50b58