### PR TITLE
Add OpenAI-backed event extraction fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 API_URL=http://localhost:8000/api/v1
 API_TOKEN=your_actual_token_here
+OPENAI_API_KEY=

--- a/README
+++ b/README
@@ -18,3 +18,18 @@ python -m jobs.run_everything
 ```
 
 Environment variables are loaded from `.env` (see `.env.example`).
+Supply your OpenAI key via `OPENAI_API_KEY`.
+
+## Processing a Single URL
+
+The collector first looks for JSON-LD metadata. If none is found, it
+falls back to sending the page text to OpenAI's structured-output API to
+extract events. For example, to ingest events from the Needham Library
+events page:
+
+```bash
+python -m jobs.process_url https://needhamlibrary.org/events/
+```
+
+The script fetches the page, extracts any events, and submits them to the
+Superschedules API.

--- a/jobs/process_url.py
+++ b/jobs/process_url.py
@@ -1,0 +1,38 @@
+"""Scrape a single URL for events and post them to the API."""
+from __future__ import annotations
+
+import sys
+from typing import List
+
+from ingest.api_client import post_event
+from scrapers.jsonld_scraper import scrape_events_from_jsonld
+from scrapers.llm_scraper import scrape_events_from_llm
+
+
+def run(url: str) -> None:
+    """Scrape events from ``url`` and post them to the backend."""
+    try:
+        events: List[dict] = scrape_events_from_jsonld(url)
+        if not events:
+            events = scrape_events_from_llm(url)
+    except Exception as exc:
+        print("❌ Failed to fetch or parse page:", exc)
+        return
+
+    if not events:
+        print("No events found at", url)
+        return
+
+    for event in events:
+        try:
+            result = post_event(event)
+            print("✅ Posted:", result.get("title", "<unknown>"))
+        except Exception as exc:  # pragma: no cover - logging only
+            print("❌ Failed to post event:", event.get("title", "<unknown>"), exc)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python -m jobs.process_url <url>")
+        raise SystemExit(1)
+    run(sys.argv[1])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 requests
 python-dotenv
 beautifulsoup4
+openai
+trafilatura
+readability-lxml
+lxml

--- a/scrapers/jsonld_scraper.py
+++ b/scrapers/jsonld_scraper.py
@@ -1,0 +1,75 @@
+"""Scrape JSON-LD event data from webpages."""
+from __future__ import annotations
+
+import json
+from typing import Any, List
+
+import requests
+from bs4 import BeautifulSoup
+
+
+def scrape_events_from_jsonld(url: str, source_id: int = 0) -> List[dict[str, Any]]:
+    """Fetch a page and extract events described in JSON-LD.
+
+    Args:
+        url: Page URL containing JSON-LD event data.
+        source_id: Numeric source identifier to include on each event.
+
+    Returns:
+        A list of event dictionaries matching the API schema.
+    """
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+
+    soup = BeautifulSoup(response.text, "html.parser")
+    events: List[dict[str, Any]] = []
+
+    for tag in soup.find_all("script", type="application/ld+json"):
+        try:
+            data = json.loads(tag.string or "")
+        except json.JSONDecodeError:
+            continue
+
+        for item in _extract_event_objects(data):
+            events.append(
+                {
+                    "source_id": source_id,
+                    "external_id": item.get("@id") or item.get("url"),
+                    "title": item.get("name", ""),
+                    "description": item.get("description", ""),
+                    "location": _parse_location(item.get("location")),
+                    "start_time": item.get("startDate"),
+                    "end_time": item.get("endDate"),
+                    "url": item.get("url", url),
+                }
+            )
+
+    return events
+
+
+def _extract_event_objects(data: Any) -> List[dict[str, Any]]:
+    """Return event dicts from a JSON-LD blob."""
+    items: List[dict[str, Any]] = []
+
+    if isinstance(data, list):
+        for obj in data:
+            if isinstance(obj, dict) and obj.get("@type") == "Event":
+                items.append(obj)
+    elif isinstance(data, dict):
+        if data.get("@type") == "Event":
+            items.append(data)
+        elif isinstance(data.get("@graph"), list):
+            for obj in data["@graph"]:
+                if isinstance(obj, dict) and obj.get("@type") == "Event":
+                    items.append(obj)
+
+    return items
+
+
+def _parse_location(location: Any) -> str:
+    """Extract a human-readable location string."""
+    if isinstance(location, dict):
+        return location.get("name") or location.get("address", "")
+    if isinstance(location, str):
+        return location
+    return ""

--- a/scrapers/llm_scraper.py
+++ b/scrapers/llm_scraper.py
@@ -1,0 +1,95 @@
+"""Extract events from page text via OpenAI's structured output API."""
+from __future__ import annotations
+
+from typing import Any, List
+
+import trafilatura
+from openai import OpenAI
+
+client = OpenAI()
+
+EVENT_SCHEMA = {
+    "name": "Events",
+    "schema": {
+        "type": "object",
+        "properties": {
+            "source": {"type": "string"},
+            "events": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["title", "start"],
+                    "properties": {
+                        "title": {"type": "string"},
+                        "description": {"type": "string"},
+                        "start": {"type": "string", "description": "ISO 8601 datetime or date"},
+                        "end": {"type": "string"},
+                        "timezone": {"type": "string"},
+                        "location": {"type": "string"},
+                        "organizer": {"type": "string"},
+                        "price": {"type": "string"},
+                        "url": {"type": "string", "format": "uri"},
+                    },
+                },
+            },
+        },
+        "required": ["source", "events"],
+        "additionalProperties": False,
+    },
+}
+
+SYSTEM_PROMPT = (
+    "You extract events from arbitrary webpage text.\n"
+    "- Output *only* fields defined by the schema.\n"
+    "- Normalize dates to ISO 8601; if only a day is given, use YYYY-MM-DD.\n"
+    "- If timezone is implied by the venue or page, include it (IANA tz).\n"
+    "- Include the canonical event URL when present."
+)
+
+
+def fetch_text(url: str) -> str:
+    """Return clean text content for ``url`` using Trafilatura."""
+    downloaded = trafilatura.fetch_url(url, no_ssl=False)
+    if not downloaded:
+        raise RuntimeError("Failed to fetch")
+    return trafilatura.extract(downloaded, include_comments=False, include_tables=True) or ""
+
+
+def parse_events(url: str) -> dict[str, Any]:
+    """Use OpenAI to parse events from ``url`` into the structured schema."""
+    text = fetch_text(url)
+    if not text or len(text) < 200:
+        return {"source": url, "events": []}
+
+    resp = client.responses.create(
+        model="o4-mini",
+        reasoning={"effort": "low"},
+        input=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": f"URL: {url}\n\nPAGE_TEXT:\n{text[:120000]}"},
+        ],
+        response_format={"type": "json_schema", "json_schema": EVENT_SCHEMA},
+    )
+    data = resp.output_parsed  # already a dict matching EVENT_SCHEMA
+    data["source"] = data.get("source") or url
+    return data
+
+
+def scrape_events_from_llm(url: str, source_id: int = 0) -> List[dict[str, Any]]:
+    """Fetch ``url`` and convert extracted events to the API schema."""
+    data = parse_events(url)
+    events: List[dict[str, Any]] = []
+    for item in data.get("events", []):
+        events.append(
+            {
+                "source_id": source_id,
+                "external_id": item.get("url"),
+                "title": item.get("title", ""),
+                "description": item.get("description", ""),
+                "location": item.get("location", ""),
+                "start_time": item.get("start"),
+                "end_time": item.get("end"),
+                "url": item.get("url", url),
+            }
+        )
+    return events


### PR DESCRIPTION
## Summary
- add LLM-based scraper that uses OpenAI structured outputs to parse events from page text
- fall back to the LLM scraper when no JSON-LD events are found
- document OpenAI key usage and update dependencies

## Testing
- `python -m jobs.process_url https://needhamlibrary.org/events/` *(fails: OpenAIError - api_key must be set)*

------
https://chatgpt.com/codex/tasks/task_e_6896559a6e708333b1afc97a39b50b58