### PR TITLE
Use Responses.parse for structured LLM events

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ openai
 trafilatura
 readability-lxml
 lxml
+pydantic


### PR DESCRIPTION
## Summary
- Replace deprecated `response_format` usage with `responses.parse` and Pydantic models
- Add Pydantic dependency

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile scrapers/llm_scraper.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689665467044833388a66f1ee6ef737d