### PR TITLE
Send raw HTML to LLM for event extraction

### DIFF
--- a/README
+++ b/README
@@ -23,9 +23,9 @@ Supply your OpenAI key via `OPENAI_API_KEY`.
 ## Processing a Single URL
 
 The collector first looks for JSON-LD metadata. If none is found, it
-falls back to sending the page text to OpenAI's structured-output API to
-extract events. For example, to ingest events from the Needham Library
-events page:
+falls back to sending the page's raw HTML to OpenAI's structured-output
+API to extract events. For example, to ingest events from the Needham
+Library events page:
 
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,4 @@ requests
 python-dotenv
 beautifulsoup4
 openai
-trafilatura
-readability-lxml
-lxml
 pydantic


### PR DESCRIPTION
## Summary
- Fetch raw HTML and send full page to OpenAI for event parsing
- Document that fallback uses raw HTML instead of sanitized text
- Drop unused scraping dependencies

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68966b5e5b748333a193253ac8b4ebe4