### PR TITLE
Send raw HTML to LLM for event extraction

### DIFF
--- a/README
+++ b/README
@@ -23,9 +23,9 @@ Supply your OpenAI key via `OPENAI_API_KEY`.
 ## Processing a Single URL
 
 The collector first looks for JSON-LD metadata. If none is found, it
-falls back to sending the page text to OpenAI's structured-output API to
-extract events. For example, to ingest events from the Needham Library
-events page:
+falls back to sending the page's raw HTML to OpenAI's structured-output
+API to extract events. For example, to ingest events from the Needham
+Library events page:
 
 
 ```bash
@@ -33,4 +33,5 @@ python -m jobs.process_url https://needhamlibrary.org/events/
 ```
 
 The script fetches the page, extracts any events, and submits them to the
-Superschedules API.
+Superschedules API. Set ``SCRAPER_DEBUG=1`` to log which scraper was used
+and the events returned.

--- a/jobs/process_url.py
+++ b/jobs/process_url.py
@@ -1,27 +1,46 @@
 """Scrape a single URL for events and post them to the API."""
 from __future__ import annotations
 
+import os
 import sys
+import logging
 from typing import List
 
 from ingest.api_client import post_event
 from scrapers.jsonld_scraper import scrape_events_from_jsonld
 from scrapers.llm_scraper import scrape_events_from_llm
-import requests
+
+logger = logging.getLogger(__name__)
+if os.getenv("SCRAPER_DEBUG"):
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
 
 def run(url: str) -> None:
     """Scrape events from ``url`` and post them to the backend."""
     try:
+        logger.info("Attempting JSON-LD scrape")
         events: List[dict] = scrape_events_from_jsonld(url)
+        logger.info("JSON-LD scraper returned %d event(s)", len(events))
+        method = "jsonld"
         if not events:
+            logger.info("No JSON-LD events found, falling back to LLM")
             events = scrape_events_from_llm(url)
+            method = "llm"
+            logger.info("LLM scraper returned %d event(s)", len(events))
     except Exception as exc:
         print("❌ Failed to fetch or parse page:", exc)
         return
 
+    logger.info("Using %s scraper", method)
+
     if not events:
         print("No events found at", url)
         return
+
+    if logger.isEnabledFor(logging.INFO):
+        logger.info("Events found:")
+        for event in events:
+            logger.info("  %s", event)
 
     for event in events:
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,4 @@ requests
 python-dotenv
 beautifulsoup4
 openai
-trafilatura
-readability-lxml
-lxml
 pydantic


### PR DESCRIPTION
## Summary
- Fetch raw HTML and send full page to OpenAI for event parsing
- Document that fallback uses raw HTML instead of sanitized text
- Drop unused scraping dependencies
- Add optional debug logging to show which scraper ran and what events were found

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68966b5e5b748333a193253ac8b4ebe4