### PR TITLE
Use Playwright for rendered page text

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ beautifulsoup4
 requests-html
 openai
 pydantic
+playwright


### PR DESCRIPTION
## Summary
- Render pages with Playwright to capture visible text after removing headers and footers
- Add Playwright dependency

## Testing
- `python -m py_compile scrapers/llm_scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_689687067eb08333b60680d37d1de059