### PR TITLE
Ensure API token included when posting events

### DIFF
--- a/ingest/api_client.py
+++ b/ingest/api_client.py
@@ -10,17 +10,21 @@ from dotenv import load_dotenv
 load_dotenv()
 
 API_BASE_URL = os.getenv("API_URL", "http://localhost:8000/api/v1")
-AUTH_TOKEN = os.getenv("API_TOKEN")
 
-HEADERS = {
-    "Authorization": f"Bearer {AUTH_TOKEN}",
-    "Content-Type": "application/json",
-}
+
+def _make_headers() -> dict[str, str]:
+    """Return headers for API requests, including the auth token if set."""
+    token = os.getenv("API_TOKEN")
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
 
 
 def post_event(event: dict[str, Any]) -> dict[str, Any]:
     """Post an event dictionary to the Superschedules backend."""
     url = f"{API_BASE_URL}/events/"
-    response = requests.post(url, json=event, headers=HEADERS, timeout=30)
+    headers = _make_headers()
+    response = requests.post(url, json=event, headers=headers, timeout=30)
     response.raise_for_status()
     return response.json()


### PR DESCRIPTION
## Summary
- Generate request headers dynamically so the API token is included when sending new events.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68968e6e70f48333bcb8f24809bb9d4e