### PR TITLE
Log API calls and add dummy source script

### DIFF
--- a/ingest/api_client.py
+++ b/ingest/api_client.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import logging
 from typing import Any
 
 import requests
@@ -10,6 +11,10 @@ from dotenv import load_dotenv
 load_dotenv()
 
 API_BASE_URL = os.getenv("API_URL", "http://localhost:8000/api/v1")
+
+logger = logging.getLogger(__name__)
+if os.getenv("SCRAPER_DEBUG"):
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
 
 
 def _make_headers() -> dict[str, str]:
@@ -21,10 +26,30 @@ def _make_headers() -> dict[str, str]:
     return headers
 
 
+def _log_request(method: str, url: str, headers: dict[str, str], payload: Any | None = None) -> None:
+    """Log details about an outgoing HTTP request."""
+    logger.info("%s %s", method.upper(), url)
+    logger.info("Headers: %s", headers)
+    if payload is not None:
+        logger.info("Payload: %s", payload)
+
+
 def post_event(event: dict[str, Any]) -> dict[str, Any]:
     """Post an event dictionary to the Superschedules backend."""
     url = f"{API_BASE_URL}/events/"
     headers = _make_headers()
+    _log_request("post", url, headers, event)
     response = requests.post(url, json=event, headers=headers, timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+
+def post_dummy_source() -> dict[str, Any]:
+    """Send a placeholder source to the backend for debugging auth issues."""
+    url = f"{API_BASE_URL}/sources/"
+    payload = {"name": "Dummy Source", "url": "https://example.com"}
+    headers = _make_headers()
+    _log_request("post", url, headers, payload)
+    response = requests.post(url, json=payload, headers=headers, timeout=30)
     response.raise_for_status()
     return response.json()

--- a/jobs/send_dummy_source.py
+++ b/jobs/send_dummy_source.py
@@ -1,0 +1,12 @@
+"""Send a dummy source to the backend to verify auth."""
+from __future__ import annotations
+
+from ingest.api_client import post_dummy_source
+
+
+if __name__ == "__main__":
+    try:
+        result = post_dummy_source()
+        print("Response:", result)
+    except Exception as exc:  # pragma: no cover - debugging script
+        print("Request failed:", exc)


### PR DESCRIPTION
## Summary
- log outgoing API requests and payloads for easier backend debugging
- add helper `post_dummy_source` and script to send a dummy source to the API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896935981e4833399e14911de080b79