### PR TITLE
Generate event descriptions with LLM

### DIFF
--- a/ingest/description_generator.py
+++ b/ingest/description_generator.py
@@ -1,0 +1,37 @@
+"""Generate short event descriptions using OpenAI."""
+from __future__ import annotations
+
+from typing import Any
+
+from openai import APIStatusError, OpenAI
+
+client = OpenAI()
+
+PROMPT_TEMPLATE = (
+    "Write a brief, friendly description for a community calendar event.\n"
+    "Title: {title}\n"
+    "Location: {location}\n"
+    "Start: {start_time}\n"
+    "End: {end_time}\n"
+    "Description:"
+)
+
+
+def generate_description(event: dict[str, Any]) -> str:
+    """Return an LLM-generated description for ``event``.
+
+    The event dict should have ``title``, ``location``, ``start_time`` and
+    ``end_time`` fields. Missing fields are treated as blank strings.
+    """
+    prompt = PROMPT_TEMPLATE.format(
+        title=event.get("title", ""),
+        location=event.get("location", ""),
+        start_time=event.get("start_time", ""),
+        end_time=event.get("end_time", ""),
+    )
+    try:
+        resp = client.responses.create(model="o4-mini", input=prompt)
+    except APIStatusError as exc:  # pragma: no cover - network errors
+        raise RuntimeError("OpenAI API request failed") from exc
+    # ``output_text`` returns the combined text content from the response
+    return resp.output_text.strip()

--- a/jobs/process_url.py
+++ b/jobs/process_url.py
@@ -7,6 +7,7 @@ import logging
 from typing import List
 
 from ingest.api_client import post_event
+from ingest.description_generator import generate_description
 from scrapers.jsonld_scraper import scrape_events_from_jsonld
 from scrapers.llm_scraper import scrape_events_from_llm
 
@@ -43,6 +44,8 @@ def run(url: str) -> None:
             logger.info("  %s", event)
 
     for event in events:
+        if not event.get("description"):
+            event["description"] = generate_description(event)
         try:
             result = post_event(event)
             print("✅ Posted:", result.get("title", "<unknown>"))

--- a/scrapers/jsonld_scraper.py
+++ b/scrapers/jsonld_scraper.py
@@ -43,7 +43,7 @@ def scrape_events_from_jsonld(url: str, source_id: int = 0) -> List[dict[str, An
                     "source_id": source_id,
                     "external_id": ext_id,
                     "title": item.get("name", ""),
-                    "description": item.get("description", ""),
+                    "description": item.get("description") or "",
                     "location": _parse_location(item.get("location")),
                     "start_time": start,
                     "end_time": end,

--- a/scrapers/llm_scraper.py
+++ b/scrapers/llm_scraper.py
@@ -120,7 +120,7 @@ def scrape_events_from_llm(url: str, source_id: int = 0) -> List[dict[str, Any]]
                 "source_id": source_id,
                 "external_id": ext_id,
                 "title": item.get("title", ""),
-                "description": item.get("description", ""),
+                "description": item.get("description") or "",
                 "location": item.get("location", ""),
                 "start_time": start,
                 "end_time": end,


### PR DESCRIPTION
## Summary
- generate short event descriptions via OpenAI when none are provided
- default scraper description fields to empty strings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897418e76208333b4461d7480bc2f7a